### PR TITLE
Add conditional check for master branch in CI job

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -16,6 +16,7 @@ permissions:
 jobs:
   test-lint-type-build:
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/master' #saving minutes on gh actions
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -115,7 +115,6 @@ jobs:
   publish-pypi:
     runs-on: ubuntu-latest
     needs: bump-version
-    if: startsWith(github.ref, 'refs/tags/')
     permissions:
       id-token: write  # Required for trusted publishing
       contents: read


### PR DESCRIPTION
Introduce a conditional check to run the test-lint-type-build job only on the master branch, optimizing GitHub Actions execution time.