### PR TITLE
Add GitHub App token setup and update scraper-lib version

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -89,6 +89,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+        
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+            app-id: ${{ vars.GH_APP_ID }}
+            private-key: ${{ secrets.GH_APP_KEY }}
 
       - name: Set up Git user
         run: |

--- a/uv.lock
+++ b/uv.lock
@@ -965,9 +965,9 @@ wheels = [
 ]
 
 [[package]]
-name = "scraper-lib"
-version = "0.1.0"
-source = { virtual = "." }
+name = "scraper-lib-rmp"
+version = "0.2.5"
+source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },
     { name = "colorama" },


### PR DESCRIPTION
Integrate GitHub App token creation into the CI/CD workflow and upgrade the scraper-lib dependency to version 0.2.5.