### PR TITLE
Update CI/CD workflows to use app token for GitHub actions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -115,7 +115,7 @@ jobs:
       - name: Push changes
         uses: ad-m/github-push-action@v0.8.0
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ steps.app-token.outputs.token }}
           tags: true
 
   publish-pypi:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,5 +41,5 @@ jobs:
       - name: Push changes
         uses: ad-m/github-push-action@v0.8.0
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ steps.app-token.outputs.token }}
           tags: true


### PR DESCRIPTION
Replace the usage of the default GitHub token with an app token in CI/CD and release workflows to enhance security and access control.