### PR TITLE
Update version bump job to use GitHub App token for checkout

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -86,16 +86,17 @@ jobs:
     needs: build-docs 
     if: github.ref == 'refs/heads/master' # Build docs only on master branch merge
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-        
       - uses: actions/create-github-app-token@v1
         id: app-token
         with:
             app-id: ${{ vars.GH_APP_ID }}
             private-key: ${{ secrets.GH_APP_KEY }}
 
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+        
       - name: Set up Git user
         run: |
             git config --global user.email "ci-bot@example.com"


### PR DESCRIPTION
Modify the version bump job to utilize a GitHub App token for the checkout process, enhancing security and access control.